### PR TITLE
Anchor claude-cloud install to repo root

### DIFF
--- a/claude-cloud/install.sh
+++ b/claude-cloud/install.sh
@@ -30,6 +30,12 @@ fi
 # curl options to retry transient network failures on downloads
 curl_opts=(-fsSL --retry 3 --retry-delay 2 --retry-all-errors)
 
+# resolve the repo root from this script's own location (the parent of
+# claude-cloud/), not $PWD, so the baked DOTFILES_DIR is correct no matter which
+# cwd the setup command runs us from. ${0:A} is the absolute script path; :h:h
+# strips install.sh and the claude-cloud/ dir, leaving the repo root.
+dotfiles_dir="${0:A:h:h}"
+
 # inject git identity into ~/.zshenv so it is set in every shell on this instance.
 # appends to GIT_CONFIG_* (rather than assuming a fixed count) so it layers onto
 # any entries the environment already provides. guarded so re-runs don't duplicate it.
@@ -41,7 +47,7 @@ if ! grep -qF "$marker" "$zshenv" 2>/dev/null; then
   cat >> "$zshenv" <<EOF
 
 $marker
-DOTFILES_DIR="$PWD"
+DOTFILES_DIR="$dotfiles_dir"
 EOF
   # rest is literal; \$DOTFILES_DIR etc. are evaluated at shell startup
   cat >> "$zshenv" <<'EOF'


### PR DESCRIPTION
### What

Derive the dotfiles repo root in `claude-cloud/install.sh` from the script's own location rather than the working directory, so the `DOTFILES_DIR` value baked into `~/.zshenv` always points at the repo root that the shared Claude config symlinks resolve against.

### Why

The installer captured `DOTFILES_DIR` from `$PWD`, which made it depend on whichever directory the environment's setup command happened to run from. When the script ran from inside `claude-cloud/`, the baked path picked up a spurious `claude-cloud/` segment, so every `$DOTFILES_DIR/shared/claude/...` target gained that extra segment and the `~/.claude/CLAUDE.md` and `~/.claude/skills` symlinks dangled on each fresh cloud instance. Anchoring to the script location matches how `macos/install.sh` already resolves itself and makes the symlink targets correct regardless of the cwd.

---
_Generated by [Claude Code](https://claude.ai/code/session_013wmfx4FHren7T1G471LPmg)_