### PR TITLE
Install claude-cloud config into all known homes

### DIFF
--- a/claude-cloud/install.sh
+++ b/claude-cloud/install.sh
@@ -36,6 +36,28 @@ curl_opts=(-fsSL --retry 3 --retry-delay 2 --retry-all-errors)
 script_dir="${0:A:h}"
 dotfiles_dir="${script_dir:h}"
 
+# the per-home config (the ~/.zshenv envs and the ~/.claude config) is installed
+# into every known home on this instance, not just $HOME: the cloud env may later
+# run shells as a different user (root or claude), so seed every candidate home.
+# $HOME is logged for visibility and included in the list in case it is none of the
+# fixed paths. the list is deduped, stripping trailing slashes first so the same
+# home written two ways (e.g. /root vs /root/) isn't processed twice.
+echo "HOME is $HOME"
+orig_home="$HOME"
+homes=()
+for h in "$HOME" /root /home/claude; do
+  h=${h%/}
+  (( ${homes[(Ie)$h]} )) || homes+=("$h")
+done
+
+for home in $homes; do
+  # point HOME at this candidate so every $HOME/~ reference below (including inside
+  # sync.sh) targets it. restored to the real home after the loop for the
+  # system-wide installs further down.
+  export HOME="$home"
+  mkdir -p "$HOME"
+  echo "Installing config into $HOME..."
+
 # inject git identity into ~/.zshenv so it is set in every shell on this instance.
 # appends to GIT_CONFIG_* (rather than assuming a fixed count) so it layers onto
 # any entries the environment already provides. guarded so re-runs don't duplicate it.
@@ -83,14 +105,19 @@ esac
 EOF
 fi
 
-# install the claude config now, before the Claude runtime launches and scans
-# skills, so they load on the first session. ~/.zshenv refreshes it on every
-# shell, and the SessionStart hook in settings.json re-scans skills so a config
-# that lands after launch still takes effect in the already-running session.
-# sync.sh is a sibling of this script, so resolve it from this script's own dir.
-# `zsh -f` skips ~/.zshenv (just written above), which would otherwise re-invoke
-# sync.sh on the subshell's startup and recurse forever.
-zsh -f "$script_dir/sync.sh"
+  # install the claude config now, before the Claude runtime launches and scans
+  # skills, so they load on the first session. ~/.zshenv refreshes it on every
+  # shell, and the SessionStart hook in settings.json re-scans skills so a config
+  # that lands after launch still takes effect in the already-running session.
+  # sync.sh is a sibling of this script, so resolve it from this script's own dir.
+  # `zsh -f` skips ~/.zshenv (just written above), which would otherwise re-invoke
+  # sync.sh on the subshell's startup and recurse forever.
+  zsh -f "$script_dir/sync.sh"
+done
+
+# restore HOME for the system-wide installs below (apt packages, /usr/local/bin
+# binaries, deno) which only need to run once and should target the real home.
+export HOME="$orig_home"
 
 # apt packages: prerequisite for the curl downloads below, so install them first
 echo "Installing apt packages..."

--- a/claude-cloud/install.sh
+++ b/claude-cloud/install.sh
@@ -43,7 +43,6 @@ dotfiles_dir="${script_dir:h}"
 # fixed paths. the list is deduped, stripping trailing slashes first so the same
 # home written two ways (e.g. /root vs /root/) isn't processed twice.
 echo "HOME is $HOME"
-orig_home="$HOME"
 homes=()
 for h in "$HOME" /root /home/claude; do
   h=${h%/}
@@ -51,17 +50,16 @@ for h in "$HOME" /root /home/claude; do
 done
 
 for home in $homes; do
-  # point HOME at this candidate so every $HOME/~ reference below (including inside
-  # sync.sh) targets it. restored to the real home after the loop for the
-  # system-wide installs further down.
-  export HOME="$home"
-  mkdir -p "$HOME"
-  echo "Installing config into $HOME..."
+  # never reassign the script's own $HOME (that would steer the system-wide installs
+  # below at the wrong place). instead target $home explicitly here, and override
+  # HOME only for the sync.sh subprocess, which reads $HOME internally.
+  mkdir -p "$home"
+  echo "Installing config into $home..."
 
 # inject git identity into ~/.zshenv so it is set in every shell on this instance.
 # appends to GIT_CONFIG_* (rather than assuming a fixed count) so it layers onto
 # any entries the environment already provides. guarded so re-runs don't duplicate it.
-zshenv="$HOME/.zshenv"
+zshenv="$home/.zshenv"
 marker="# dotfiles: auto added, do not remove"
 if ! grep -qF "$marker" "$zshenv" 2>/dev/null; then
   echo "Adding envs to $zshenv..."
@@ -111,13 +109,10 @@ fi
   # that lands after launch still takes effect in the already-running session.
   # sync.sh is a sibling of this script, so resolve it from this script's own dir.
   # `zsh -f` skips ~/.zshenv (just written above), which would otherwise re-invoke
-  # sync.sh on the subshell's startup and recurse forever.
-  zsh -f "$script_dir/sync.sh"
+  # sync.sh on the subshell's startup and recurse forever. HOME is set just for this
+  # subprocess so sync.sh's $HOME/~ references land in $home without touching ours.
+  HOME="$home" zsh -f "$script_dir/sync.sh"
 done
-
-# restore HOME for the system-wide installs below (apt packages, /usr/local/bin
-# binaries, deno) which only need to run once and should target the real home.
-export HOME="$orig_home"
 
 # apt packages: prerequisite for the curl downloads below, so install them first
 echo "Installing apt packages..."


### PR DESCRIPTION
### What

Install the per-home claude-cloud config — the `~/.zshenv` envs and the `~/.claude` config synced by `sync.sh` — into every known home on the instance rather than only `$HOME`, iterating over a deduplicated list of `$HOME`, `/root`, and `/home/claude`.

### Why

The cloud environment may run shells under a different user than the one the setup script executes as (root vs claude), so config written only to `$HOME` can be invisible to the session that actually runs; seeding `/root` and `/home/claude` alongside `$HOME` ensures it lands wherever a shell starts. The list is deduplicated with trailing slashes stripped so an overlap with `$HOME` isn't processed twice, and `$HOME` is logged for visibility. The script never reassigns its own `$HOME`: each home is targeted explicitly and `HOME` is overridden only for the `sync.sh` subprocess, leaving the system-wide installs further down pointed at the real home.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oWvezjbXX74SkiwfLxZfp)_