### PR TITLE
Indent per-home config block inside loop

### DIFF
--- a/claude-cloud/install.sh
+++ b/claude-cloud/install.sh
@@ -56,21 +56,21 @@ for home in $homes; do
   mkdir -p "$home"
   echo "Installing config into $home..."
 
-# inject git identity into ~/.zshenv so it is set in every shell on this instance.
-# appends to GIT_CONFIG_* (rather than assuming a fixed count) so it layers onto
-# any entries the environment already provides. guarded so re-runs don't duplicate it.
-zshenv="$home/.zshenv"
-marker="# dotfiles: auto added, do not remove"
-if ! grep -qF "$marker" "$zshenv" 2>/dev/null; then
-  echo "Adding envs to $zshenv..."
-  # first heredoc is unquoted only to bake in the dotfiles repo path
-  cat >> "$zshenv" <<EOF
+  # inject git identity into ~/.zshenv so it is set in every shell on this instance.
+  # appends to GIT_CONFIG_* (rather than assuming a fixed count) so it layers onto
+  # any entries the environment already provides. guarded so re-runs don't duplicate it.
+  zshenv="$home/.zshenv"
+  marker="# dotfiles: auto added, do not remove"
+  if ! grep -qF "$marker" "$zshenv" 2>/dev/null; then
+    echo "Adding envs to $zshenv..."
+    # first heredoc is unquoted only to bake in the dotfiles repo path
+    cat >> "$zshenv" <<EOF
 
 $marker
 DOTFILES_DIR="$dotfiles_dir"
 EOF
-  # rest is literal; \$DOTFILES_DIR etc. are evaluated at shell startup
-  cat >> "$zshenv" <<'EOF'
+    # rest is literal; \$DOTFILES_DIR etc. are evaluated at shell startup
+    cat >> "$zshenv" <<'EOF'
 _git_config_env() {
   local i=${GIT_CONFIG_COUNT:-0}
   export GIT_CONFIG_KEY_$i="$1"
@@ -101,7 +101,7 @@ case $branch in
   claude/*) git branch -m "${branch#claude/}" ;;
 esac
 EOF
-fi
+  fi
 
   # install the claude config now, before the Claude runtime launches and scans
   # skills, so they load on the first session. ~/.zshenv refreshes it on every


### PR DESCRIPTION
### What

Re-indent the git-identity and config block in claude-cloud/install.sh so it nests under the `for home in $homes` loop, leaving the heredoc bodies and their closing `EOF` delimiters at column zero where they must stay.

### Why

PR #11 wrapped this block in a per-home loop but never re-indented its body, so the code that runs once per home was still sitting at the outer indentation level and read as if it were outside the loop. This is the indentation cleanup that did not make it into that PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zdqs9Lexdb4nr5eidZRwR)_